### PR TITLE
[fix] Correct inverted JSON output prompt logic in Team class

### DIFF
--- a/libs/agno/agno/team/team.py
+++ b/libs/agno/agno/team/team.py
@@ -5558,12 +5558,16 @@ class Team:
         if add_session_state_to_context and session_state is not None:
             system_message_content += self._get_formatted_session_state_for_system_message(session_state)
 
-        # Add the JSON output prompt if output_schema is provided and structured_outputs is False
+        # Add the JSON output prompt if output_schema is provided and the model does not support native structured outputs
+        # or JSON schema outputs, or if use_json_mode is True
         if (
             self.output_schema is not None
-            and self.use_json_mode
+            and self.parser_model is None
             and self.model
-            and self.model.supports_native_structured_outputs
+            and not (
+                (self.model.supports_native_structured_outputs or self.model.supports_json_schema_outputs)
+                and not self.use_json_mode
+            )
         ):
             system_message_content += f"{self._get_json_output_prompt()}"
 
@@ -5864,12 +5868,16 @@ class Team:
         if add_session_state_to_context and session_state is not None:
             system_message_content += self._get_formatted_session_state_for_system_message(session_state)
 
-        # Add the JSON output prompt if output_schema is provided and structured_outputs is False
+        # Add the JSON output prompt if output_schema is provided and the model does not support native structured outputs
+        # or JSON schema outputs, or if use_json_mode is True
         if (
             self.output_schema is not None
-            and self.use_json_mode
+            and self.parser_model is None
             and self.model
-            and self.model.supports_native_structured_outputs
+            and not (
+                (self.model.supports_native_structured_outputs or self.model.supports_json_schema_outputs)
+                and not self.use_json_mode
+            )
         ):
             system_message_content += f"{self._get_json_output_prompt()}"
 


### PR DESCRIPTION
## Summary

This PR fixes a bug in the Team class where the JSON output prompt logic was inverted compared to the correct implementation in the Agent class.

**The Bug:**
- Team's `get_system_message()` and `aget_system_message()` methods had backwards logic
- They added JSON output prompts when the model **DOES** support native structured outputs (incorrect)
- This caused models like LiteLLM (which report `supports_native_structured_outputs=False`) to not receive necessary JSON formatting prompts

**The Fix:**
- Changed the condition to match Agent's correct behavior (libs/agno/agno/agent/agent.py:7070-7084)
- Now adds JSON output prompts when the model does **NOT** support native structured outputs or JSON schema outputs, OR when `use_json_mode` is True
- Fixed both sync (`get_system_message`) and async (`aget_system_message`) versions

**Changes:**
- `libs/agno/agno/team/team.py` lines 5561-5572 (sync version)
- `libs/agno/agno/team/team.py` lines 5867-5882 (async version)

This ensures Team class behavior matches the working Agent class implementation for JSON output schema handling.

## Test plan
- [x] Code formatted with `./scripts/format.sh`
- [x] Code validated with `./scripts/validate.sh`
- [x] Logic now matches Agent class implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)